### PR TITLE
Switch to Grid Layout

### DIFF
--- a/src/components/NewsPaperFullPageOnline.tsx
+++ b/src/components/NewsPaperFullPageOnline.tsx
@@ -60,25 +60,25 @@ const NewsPaperFullPageOnline = (props: PaperProps) => {
     }
 
     return (
-        <div className="container">
-            <div className="frontpage text-[#000000]">
-                <div className="fp-cell fp-cell--1">
+        <div className='grid grid-cols-1 lg:grid-cols-3 md:grid-rows-2 gap-4 p-10 h-full w-full text-[#000000]'>
+            <div className='lg:row-span-2 lg:col-span-1 fp-cell'>
+                <div className="article">
                     {articleComp[3]}
                 </div>
-                <div className="fp-cell fp-cell--2">
-                    <div className="fp-cell fp-cell--1">
-                        {articleComp[0]}
-                    </div>
+            </div>
+            <div className='lg:col-span-2 col-span-1'>
+                <div className="article">
+                    {articleComp[0]}
                 </div>
-                <div className="fp-cell fp-cell--3">
-                    <div className="fp-cell fp-cell--1">
-                        {articleComp[1]}
-                    </div>
+            </div>
+            <div className='col-span-1'>
+                <div className="article">
+                    {articleComp[1]}
                 </div>
-                <div className="fp-cell fp-cell--4">
-                    <div className="fp-cell fp-cell--1">
-                        {articleComp[2]}
-                    </div>
+            </div>
+            <div className='col-span-1'>
+                <div className="article">
+                    {articleComp[2]}
                 </div>
             </div>
         </div>

--- a/src/components/NewsPaperOnlineArticle.css
+++ b/src/components/NewsPaperOnlineArticle.css
@@ -14,7 +14,13 @@
   .fp-cell {
     background-color: #fff;
     padding: 16px;
-    height:100%;
+  }
+
+  .article {
+    background-color: #fff;
+    padding: 16px;
+    overflow: auto;
+    height: -webkit-fill-available;
   }
   
   .fp-cell--1 {


### PR DESCRIPTION
This is a major move to using a full grid layout. This improves the flexability of the newspaper on screen sizes and when in editing mode. This does however currently require a user to scroll within an article on a larger screen. That is something that can be looked at later. 